### PR TITLE
Add CSS rule to prevent double underline in TOC

### DIFF
--- a/main.html
+++ b/main.html
@@ -195,6 +195,12 @@
       font-size: 13px;
       font-weight: 600;
     }
+
+    d-contents nav>div>a:hover,
+    d-contents nav>ul>li>a:hover {
+        text-decoration: none;
+    }
+
     /* code blocks to margins */
     @media (min-width: 1600px) {
       d-code {

--- a/public/index.html
+++ b/public/index.html
@@ -195,6 +195,12 @@
       font-size: 13px;
       font-weight: 600;
     }
+
+    d-contents nav>div>a:hover,
+    d-contents nav>ul>li>a:hover {
+        text-decoration: none;
+    }
+
     /* code blocks to margins */
     @media (min-width: 1600px) {
       d-code {


### PR DESCRIPTION
Assuming this wasn't by design. 

Before: 
<img width="255" alt="Screen Shot 2020-03-10 at 10 54 40 PM" src="https://user-images.githubusercontent.com/5741691/76377814-3fe17700-6322-11ea-8f3e-a6f3c9c6abfe.png">

After:
<img width="249" alt="Screen Shot 2020-03-10 at 10 54 24 PM" src="https://user-images.githubusercontent.com/5741691/76377821-44a62b00-6322-11ea-809f-190418ab455d.png">
